### PR TITLE
Fix bug: npm plug 'lozad' conflicts with this plug.

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,20 +13,20 @@ hexo.extend.filter.register('after_post_render', function (data) {
       let key = toprocess[i];
       let $ = cheerio.load(data[key], { ignoreWhitespace: false, xmlMode: false, lowerCaseTags: false, decodeEntities: false });
       $('img').each(function () {
-        let  src_key = ''
+        let src_key = ''
         if ($(this).attr('src')) {
           src_key = 'src'
         } else if ($(this).attr('data-src')) {
           src_key = 'data-src'
         }
         if (src_key) {
-          let src = $(this).attr('data-src').replace('\\', '/');
+          let src = $(this).attr(src_key).replace('\\', '/');
           if (!(/http[s]*.*|\/\/.*/.test(src) || /^\s+\//.test(src) || /^\s*\/uploads|images\//.test(src))) {
             let linkArray = link.split('/').filter(function (elem) { return elem != ''; });
             let srcArray = src.split('/').filter(function (elem) { return elem != '' && elem != '.'; });
             if (srcArray.length > 1) { srcArray.shift(); }
             src = srcArray.join('/');
-            $(this).attr('data-src', config.root + link + src);
+            $(this).attr(src_key, config.root + link + src);
           }
         } else {
           console.info && console.info($(this));

--- a/index.js
+++ b/index.js
@@ -13,14 +13,20 @@ hexo.extend.filter.register('after_post_render', function (data) {
       let key = toprocess[i];
       let $ = cheerio.load(data[key], { ignoreWhitespace: false, xmlMode: false, lowerCaseTags: false, decodeEntities: false });
       $('img').each(function () {
+        let  src_key = ''
         if ($(this).attr('src')) {
-          let src = $(this).attr('src').replace('\\', '/');
+          src_key = 'src'
+        } else if ($(this).attr('data-src')) {
+          src_key = 'data-src'
+        }
+        if (src_key) {
+          let src = $(this).attr('data-src').replace('\\', '/');
           if (!(/http[s]*.*|\/\/.*/.test(src) || /^\s+\//.test(src) || /^\s*\/uploads|images\//.test(src))) {
             let linkArray = link.split('/').filter(function (elem) { return elem != ''; });
             let srcArray = src.split('/').filter(function (elem) { return elem != '' && elem != '.'; });
             if (srcArray.length > 1) { srcArray.shift(); }
             src = srcArray.join('/');
-            $(this).attr('src', config.root + link + src);
+            $(this).attr('data-src', config.root + link + src);
           }
         } else {
           console.info && console.info($(this));


### PR DESCRIPTION
Fix bug: npm plug 'lozad' conflicts with this plug, because 'lozad' use img['data-src'] instead of img['src'].
This bug found is found by https://ekibun.github.io/ekibook/2020/04/07/hexoimage/
This commit uses img['data-src'] when img['src'] is empty.

npm plug 'lozad' conflicts with this plug:
~~~
# hexo clean && hexo g && hexo s
INFO  Validating config
INFO  Deleted database.
INFO  Deleted public folder.
INFO  Validating config
INFO  Start processing
initialize {
  '0': {
    type: 'tag',
    name: 'img',
    attribs: {
      'data-src': 'main/ScreenShot%202020-02-29%2002.08.48.png',
      alt: 'ScreenShot 2020-02-29 02.08.48'
    },
    children: [],
    next: null,
    prev: {
      data: '  some words ahead',
      type: 'text',
      next: [Circular],
      prev: null,
      parent: [Object]
    },
    parent: {
      type: 'tag',
      name: 'p',
      attribs: {},
      children: [Array],
      next: [Object],
      prev: null,
      parent: [Object]
    }
  },
~~~